### PR TITLE
fix: rename NEXTAUTH_SECRET/URL to AUTH_SECRET/URL for NextAuth v5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,8 @@ NEXT_PUBLIC_WP_MEDIA_HOSTNAME=cms.joseLeos.com
 
 # ─── Authentication (NextAuth v5) ─────────────────────────────────────────────
 # Generate with: openssl rand -base64 32
-NEXTAUTH_SECRET=your-nextauth-secret
-NEXTAUTH_URL=http://localhost:4000
+AUTH_SECRET=your-auth-secret
+AUTH_URL=http://localhost:4000
 
 # Email address that receives owner-level access (isOwner = true)
 OWNER_EMAIL=jose@joseleos.com

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ JoseLeos.com/
 | `NEXT_PUBLIC_SITE_URL` | Yes | Canonical base URL used in OG tags and share links (e.g. `https://joseleos.com`) |
 | `NEXT_PUBLIC_WORDPRESS_API_URL` | Yes | WPGraphQL endpoint on your WordPress instance (e.g. `https://cms.joseleos.com/graphql`) |
 | `NEXT_PUBLIC_WP_MEDIA_HOSTNAME` | Yes | Hostname of your WordPress media server, added to the Next.js Image allowlist |
-| `NEXTAUTH_SECRET` | Yes | Random string used to sign NextAuth JWTs and cookies |
-| `NEXTAUTH_URL` | Yes | Base URL for NextAuth callbacks (set to your production URL on Vercel) |
+| `AUTH_SECRET` | Yes | Random string used to sign NextAuth JWTs and cookies (`openssl rand -base64 32`) |
+| `AUTH_URL` | Yes | Base URL for NextAuth callbacks (set to your production URL on Vercel) |
 | `AUTH_RESEND_KEY` | Yes | Resend API key used by NextAuth to send magic-link emails |
 | `AUTH_EMAIL_FROM` | No | Sender address for auth emails (defaults to `Jose Leos <auth@joseleos.com>`) |
 | `OWNER_EMAIL` | Yes | Email address granted owner-level access (`isOwner = true` in session) |


### PR DESCRIPTION
NextAuth v5 reads AUTH_SECRET and AUTH_URL, not NEXTAUTH_SECRET/URL. The dev server was throwing MissingSecret errors because of this mismatch.

https://claude.ai/code/session_01N1YAkWGf6esRPAZVZr5FRT