### PR TITLE
ci: use RELEASE_PLEASE_TOKEN PAT if available

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           release-type: node
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
GITHUB_TOKEN cannot open PRs in repos where Actions are restricted from creating pull requests. Falls back to GITHUB_TOKEN if the secret is not set.

https://claude.ai/code/session_01N1YAkWGf6esRPAZVZr5FRT