### PR TITLE
docs: add Recent Updates section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ the newest entry below is still in review. For the full generated history see [C
 - **Infrastructure & CI** — Every pull request now has its title linted against Conventional
   Commits, and releases are cut automatically, so the changelog and GitHub Releases are generated
   rather than hand-maintained (`d394de8`).
-- **Infrastructure & CI** — Release automation is being moved to release-please v5 and pr-title v6
-  with an hourly self-heal tick, replacing a fine-grained PAT that reproducibly broke tagging
-  (`d1f53a9`, in review on `chore/ci-hardening`).
+- **Infrastructure & CI** — Release automation switched to a fine-grained PAT to work around
+  org-level token restrictions (`d1f53a9`); that PAT reproducibly broke tagging, so a follow-up
+  moving to release-please v5 and pr-title v6 with an hourly self-heal tick is in review.
 - **Auth & API** — Magic-link sign-in reads the NextAuth v5 environment names (`AUTH_SECRET` /
   `AUTH_URL`), fixing logins that failed silently against the old `NEXTAUTH_*` names (`7613431`).
 - **App & Pages** — The About, Resume, Now, and Uses pages show explicit TODO placeholders instead

--- a/README.md
+++ b/README.md
@@ -6,6 +6,27 @@
 
 JoseLeos.com is a full-stack personal site built with Next.js 16 (App Router) and a headless WordPress backend served via WPGraphQL. It combines a project portfolio, a long-form blog, and a curated recommendations section with a three-tier access control system that gates content for public visitors, authenticated members, and the site owner. All content is managed in WordPress with ACF custom fields; the Next.js frontend fetches it at build and request time via Apollo Client.
 
+## Recent Updates
+
+*Last reviewed 2026-08-14. Covers work through `v0.1.1` — `main` has no commits after that tag, so
+the newest entry below is still in review. For the full generated history see [CHANGELOG.md](CHANGELOG.md).*
+
+- **Infrastructure & CI** — Every pull request now has its title linted against Conventional
+  Commits, and releases are cut automatically, so the changelog and GitHub Releases are generated
+  rather than hand-maintained (`d394de8`).
+- **Infrastructure & CI** — Release automation is being moved to release-please v5 and pr-title v6
+  with an hourly self-heal tick, replacing a fine-grained PAT that reproducibly broke tagging
+  (`d1f53a9`, in review on `chore/ci-hardening`).
+- **Auth & API** — Magic-link sign-in reads the NextAuth v5 environment names (`AUTH_SECRET` /
+  `AUTH_URL`), fixing logins that failed silently against the old `NEXTAUTH_*` names (`7613431`).
+- **App & Pages** — The About, Resume, Now, and Uses pages show explicit TODO placeholders instead
+  of stale filler, so unfinished sections read as intentional rather than broken (`27f799e`).
+- **Content & Copy** — The interim landing page gained a working contact form, a square-cropped
+  profile headshot, refreshed social links, and a scheduling call-to-action (`6aa66ec`, `b46c145`,
+  `ad24205`).
+- **Content & Copy** — The README's architecture and setup docs were audited against the routes
+  that actually ship, so the documented structure matches the real one (`eb8912b`).
+
 ## Tech Stack
 
 | Layer | Technology |


### PR DESCRIPTION
## What

Adds a `## Recent Updates` section to `README.md`, inserted between the Overview intro block and the `## Tech Stack` table.

## Why

Gives readers a lightweight, human-readable summary of recent work framed by user-facing impact, as a companion to the machine-generated `CHANGELOG.md` rather than a duplicate of it.

## Contents

Six bullets grouped by area, each with commit refs:

- **Infrastructure & CI** — Conventional Commits PR-title linting + automated releases (`d394de8`); the in-review move to release-please v5 / pr-title v6 (`d1f53a9`)
- **Auth & API** — NextAuth v5 `AUTH_SECRET` / `AUTH_URL` rename (`7613431`)
- **App & Pages** — TODO placeholders on About/Resume/Now/Uses (`27f799e`)
- **Content & Copy** — landing-page contact form, headshot, social links, scheduling CTA (`6aa66ec`, `b46c145`, `ad24205`); README accuracy audit (`eb8912b`)

## Note on scope

`git describe --tags --abbrev=0` resolves to `v0.1.1`, and `git log v0.1.1..HEAD` on `main` is **empty** — there are no released commits after the tag. The section therefore summarises the `v0.1.0..v0.1.1` window plus the in-flight CI hardening, and says so inline so the dating is not misleading. On later runs the section is updated in place.

## Out of scope

Docs-only. No application source changes, no version bump, no tags, and no edits to `CHANGELOG.md`, `CLAUDE.md`, or `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)