### PR TITLE
test: expand E2E coverage — auth, middleware, subscribe + fix playwright baseURL port

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: [["html", { open: "never" }], ["list"]],
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
+    // `npm run dev` serves on 4000 (next dev -p 4000).
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:4000",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
   },
@@ -27,8 +28,16 @@ export default defineConfig({
     ? undefined
     : {
         command: "npm run dev",
-        url: "http://localhost:3000",
+        url: "http://localhost:4000",
         reuseExistingServer: true,
         timeout: 120_000,
+        env: {
+          // NextAuth refuses to start without a secret, and proxy.ts wraps every
+          // gated route in auth() — without this the route-protection tests get
+          // a 500 instead of the redirect. Signing-only; no backend is contacted.
+          AUTH_SECRET:
+            process.env.AUTH_SECRET ?? "e2e-test-secret-not-for-production",
+          AUTH_URL: process.env.AUTH_URL ?? "http://localhost:4000",
+        },
       },
 });

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Auth flow coverage. No real email is ever sent: the NextAuth REST endpoints
+ * under /api/auth/** are mocked so `signIn("resend", ...)` resolves without
+ * touching Resend or Postgres.
+ */
+
+/** Minimal stand-in for the NextAuth endpoints `signIn()` hits. */
+async function mockNextAuth(
+  page: import("@playwright/test").Page,
+  signInResponse: Record<string, unknown>
+) {
+  await page.route("**/api/auth/csrf", (route) =>
+    route.fulfill({ json: { csrfToken: "test-csrf-token" } })
+  );
+  await page.route("**/api/auth/providers", (route) =>
+    route.fulfill({
+      json: {
+        resend: {
+          id: "resend",
+          name: "Resend",
+          type: "email",
+          signinUrl: "/api/auth/signin/resend",
+          callbackUrl: "/api/auth/callback/resend",
+        },
+      },
+    })
+  );
+  await page.route("**/api/auth/signin/resend**", (route) =>
+    route.fulfill({ json: signInResponse })
+  );
+}
+
+test.describe("Login page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/login");
+  });
+
+  test("renders the sign-in card with email field and submit button", async ({ page }) => {
+    await expect(page.getByRole("link", { name: /Jose Leos/i })).toBeVisible();
+    await expect(page.getByText(/Sign in to access member content/i)).toBeVisible();
+    await expect(page.getByLabel(/Email address/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /Send magic link/i })).toBeVisible();
+  });
+
+  test("explains that no password is required", async ({ page }) => {
+    await expect(page.getByText(/secure sign-in link\. No password required/i)).toBeVisible();
+  });
+
+  test("email field is a required email input", async ({ page }) => {
+    const email = page.getByLabel(/Email address/i);
+    await expect(email).toHaveAttribute("type", "email");
+    await expect(email).toHaveAttribute("required", "");
+    await expect(email).toHaveAttribute("placeholder", /you@example\.com/i);
+  });
+
+  test("an invalid email keeps the user on the login page", async ({ page }) => {
+    await page.getByLabel(/Email address/i).fill("not-an-email");
+    await page.getByRole("button", { name: /Send magic link/i }).click();
+
+    // Native constraint validation blocks submission — no navigation occurs.
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByRole("button", { name: /Send magic link/i })).toBeVisible();
+  });
+
+  test("a valid email sends the user to the verify page", async ({ page }) => {
+    await mockNextAuth(page, { url: "/login/verify" });
+
+    await page.getByLabel(/Email address/i).fill("visitor@example.com");
+    await page.getByRole("button", { name: /Send magic link/i }).click();
+
+    await expect(page).toHaveURL(/\/login\/verify$/);
+  });
+
+  test("shows an inline error when sign-in fails", async ({ page }) => {
+    await mockNextAuth(page, { error: "EmailSignInError", url: null });
+
+    await page.getByLabel(/Email address/i).fill("visitor@example.com");
+    await page.getByRole("button", { name: /Send magic link/i }).click();
+
+    await expect(page.getByText(/Something went wrong\. Please try again\./i)).toBeVisible();
+    await expect(page).toHaveURL(/\/login$/);
+  });
+});
+
+test.describe("Magic-link verify page", () => {
+  test("tells the user to check their email", async ({ page }) => {
+    await page.goto("/login/verify");
+    await expect(page.getByRole("heading", { name: /Check your email/i, level: 1 })).toBeVisible();
+    await expect(page.getByText(/We sent a magic link/i)).toBeVisible();
+  });
+
+  test("offers a way back to try a different email", async ({ page }) => {
+    await page.goto("/login/verify");
+    await page.getByRole("link", { name: /Use a different email/i }).click();
+    await expect(page).toHaveURL(/\/login$/);
+  });
+});
+
+test.describe("Sign-in error page", () => {
+  test("shows the generic message with no error code", async ({ page }) => {
+    await page.goto("/login/error");
+    await expect(page.getByRole("heading", { name: /Sign-in failed/i, level: 1 })).toBeVisible();
+    await expect(page.getByText(/An unexpected error occurred/i)).toBeVisible();
+  });
+
+  test("explains an expired or reused magic link", async ({ page }) => {
+    await page.goto("/login/error?error=Verification");
+    await expect(
+      page.getByText(/magic link has expired or has already been used/i)
+    ).toBeVisible();
+  });
+
+  test("explains a denied sign-in", async ({ page }) => {
+    await page.goto("/login/error?error=AccessDenied");
+    await expect(page.getByText(/do not have permission to sign in/i)).toBeVisible();
+  });
+
+  test("falls back to the generic message for an unknown code", async ({ page }) => {
+    await page.goto("/login/error?error=SomethingUnmapped");
+    await expect(page.getByText(/An unexpected error occurred/i)).toBeVisible();
+  });
+
+  test("the try-again link returns to login", async ({ page }) => {
+    await page.goto("/login/error");
+    await page.getByRole("link", { name: /Try again/i }).click();
+    await expect(page).toHaveURL(/\/login$/);
+  });
+});

--- a/tests/e2e/middleware.spec.ts
+++ b/tests/e2e/middleware.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Route-protection coverage for proxy.ts. Every test here runs with a clean,
+ * signed-out context, so these assert the unauthenticated path only — no
+ * session cookie is ever minted and no backend is contacted.
+ */
+
+const GATED_ROUTES = ["/dashboard", "/account"];
+
+test.describe("Gated routes redirect signed-out visitors to /login", () => {
+  for (const route of GATED_ROUTES) {
+    test(`${route} redirects to /login`, async ({ page }) => {
+      await page.goto(route);
+      await expect(page).toHaveURL(/\/login$/);
+    });
+
+    test(`${route} lands on a usable sign-in form`, async ({ page }) => {
+      await page.goto(route);
+      await expect(page.getByLabel(/Email address/i)).toBeVisible();
+      await expect(page.getByRole("button", { name: /Send magic link/i })).toBeVisible();
+    });
+
+    test(`${route} sub-paths are also protected`, async ({ page }) => {
+      await page.goto(`${route}/some/nested/path`);
+      await expect(page).toHaveURL(/\/login$/);
+    });
+  }
+});
+
+test.describe("Public routes are not gated", () => {
+  for (const route of ["/", "/about", "/contact", "/subscribe"]) {
+    test(`${route} renders without redirecting to /login`, async ({ page }) => {
+      await page.goto(route);
+      await expect(page).not.toHaveURL(/\/login/);
+    });
+  }
+});
+
+test.describe("Middleware matcher scope", () => {
+  test("a route merely prefixed with 'account' is not gated", async ({ page }) => {
+    // The matcher is /account/:path* — an unrelated route sharing the prefix
+    // should fall through to the normal 404, not the login redirect.
+    await page.goto("/accounts-payable-does-not-exist");
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+});

--- a/tests/e2e/subscribe.spec.ts
+++ b/tests/e2e/subscribe.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Newsletter signup coverage. /api/subscribe is always mocked — the real route
+ * talks to Resend and HubSpot, neither of which is reachable in CI.
+ */
+
+test.describe("Subscribe page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/subscribe");
+  });
+
+  test("renders the heading and signup form", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: /Get the newsletter/i, level: 1 })).toBeVisible();
+    await expect(page.getByPlaceholder(/you@example\.com/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /Subscribe/i })).toBeVisible();
+  });
+
+  test("links back to the newsletter archive", async ({ page }) => {
+    await page.getByRole("link", { name: /Browse past issues/i }).click();
+    await expect(page).toHaveURL(/\/newsletter$/);
+  });
+
+  test("email field is a required email input", async ({ page }) => {
+    const email = page.getByPlaceholder(/you@example\.com/i);
+    await expect(email).toHaveAttribute("type", "email");
+    await expect(email).toHaveAttribute("required", "");
+  });
+
+  test("an invalid email does not submit the form", async ({ page }) => {
+    let called = false;
+    await page.route("**/api/subscribe", (route) => {
+      called = true;
+      return route.fulfill({ json: { success: true } });
+    });
+
+    await page.getByPlaceholder(/you@example\.com/i).fill("nope");
+    await page.getByRole("button", { name: /Subscribe/i }).click();
+
+    // Native constraint validation blocks the request entirely.
+    await expect(page.getByRole("button", { name: /Subscribe/i })).toBeVisible();
+    expect(called).toBe(false);
+  });
+
+  test("shows the success state after subscribing", async ({ page }) => {
+    await page.route("**/api/subscribe", (route) =>
+      route.fulfill({ json: { success: true } })
+    );
+
+    await page.getByPlaceholder(/you@example\.com/i).fill("reader@example.com");
+    await page.getByRole("button", { name: /Subscribe/i }).click();
+
+    await expect(page.getByText(/You.re subscribed!/i)).toBeVisible();
+  });
+
+  test("tells an existing subscriber they are already signed up", async ({ page }) => {
+    await page.route("**/api/subscribe", (route) =>
+      route.fulfill({ json: { alreadySubscribed: true } })
+    );
+
+    await page.getByPlaceholder(/you@example\.com/i).fill("returning@example.com");
+    await page.getByRole("button", { name: /Subscribe/i }).click();
+
+    await expect(page.getByText(/You.re already subscribed/i)).toBeVisible();
+  });
+
+  test("shows an error state when the API fails", async ({ page }) => {
+    await page.route("**/api/subscribe", (route) =>
+      route.fulfill({ status: 500, json: { error: "Failed to subscribe. Please try again." } })
+    );
+
+    await page.getByPlaceholder(/you@example\.com/i).fill("reader@example.com");
+    await page.getByRole("button", { name: /Subscribe/i }).click();
+
+    await expect(page.getByText(/Something went wrong — please try again/i)).toBeVisible();
+  });
+
+  test("shows an error state when the newsletter is unconfigured", async ({ page }) => {
+    await page.route("**/api/subscribe", (route) =>
+      route.fulfill({ status: 503, json: { error: "Newsletter not configured." } })
+    );
+
+    await page.getByPlaceholder(/you@example\.com/i).fill("reader@example.com");
+    await page.getByRole("button", { name: /Subscribe/i }).click();
+
+    await expect(page.getByText(/Something went wrong — please try again/i)).toBeVisible();
+  });
+
+  test("disables the button while the request is in flight", async ({ page }) => {
+    await page.route("**/api/subscribe", async (route) => {
+      await new Promise((r) => setTimeout(r, 750));
+      await route.fulfill({ json: { success: true } });
+    });
+
+    await page.getByPlaceholder(/you@example\.com/i).fill("reader@example.com");
+    await page.getByRole("button", { name: /Subscribe/i }).click();
+
+    await expect(page.getByRole("button", { name: "…" })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds 3 new E2E test files written by Claude Code (Skill 3 from the Aug 14 run):

- `tests/e2e/auth.spec.ts` — login page rendering, form states, NextAuth endpoints mocked
- `tests/e2e/middleware.spec.ts` — /dashboard + /account redirect to /login for unauthenticated users; public routes verified as ungated
- `tests/e2e/subscribe.spec.ts` — newsletter form validation states with mocked API

Also fixes a bug in `playwright.config.ts`: baseURL was `localhost:3000` but dev server runs on port 4000.

Note: blog-taxonomy.spec.ts and recommendations.spec.ts were planned but not written before the time budget ran out — can be added as a follow-up.