### PR TITLE
chore: audit conventional commits config against canonical spec

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,10 @@
 name: PR Title Lint
 
+# pull_request_target (not pull_request) so the linter also runs on PRs opened
+# from forks, where the pull_request event's GITHUB_TOKEN is read-only and the
+# check cannot be reported. No PR code is checked out, so this is safe.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 permissions:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
   "changelog-sections": [
     { "type": "feat",     "section": "Features" },
     { "type": "fix",      "section": "Bug Fixes" },


### PR DESCRIPTION
Audit of the existing Conventional Commits + release-please setup against the canonical spec. Only real gaps are changed — everything else already conformed.

## Gaps found and fixed

| File | Gap | Fix |
|---|---|---|
| `.github/workflows/pr-title.yml` | trigger was `pull_request` | switched to `pull_request_target` so the linter also runs on fork PRs, where `pull_request` yields a read-only token and the check cannot be reported |
| `release-please-config.json` | `bump-patch-for-minor-pre-major` absent | added explicitly as `false`, pinning `feat` → minor pre-1.0 (matches the table in CONTRIBUTING.md) |

## Already conformant (no change)

- `pr-title.yml`: `amannn/action-semantic-pull-request@v6`, top-level `permissions: pull-requests: read`, `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` in job env, no empty YAML array inputs
- `release-please.yml`: `googleapis/release-please-action@v5`, hourly `45 * * * *` self-heal cron, `workflow_dispatch`, `contents/pull-requests/checks: write`, synthetic "Lint pr title" check-run step, Node24 env
- `release-please-config.json`: `release-type: node`, `bump-minor-pre-major: true`
- `CONTRIBUTING.md`: documents Conventional Commits types, version bump rules, and that `CHANGELOG.md` is generated (never hand-edited)

## Note on `RELEASE_PLEASE_TOKEN`

The string still appears in `release-please.yml`, but only inside a comment warning *against* using a PAT — `token:` is `secrets.GITHUB_TOKEN`. There is no functional reference, so the guardrail comment was left in place.

Both workflow files were YAML-validated and the config JSON-parsed after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)