### PR TITLE
test: QA loop — new E2E tests for API routes + triage results

### DIFF
--- a/tests/e2e/QA_REPORT.md
+++ b/tests/e2e/QA_REPORT.md
@@ -1,0 +1,138 @@
+# QA Report — 2026-08-15
+
+Closed-loop QA pass over the Playwright E2E suite: audit coverage → add specs for the
+uncovered API routes → run → triage → fix → re-run. Three iterations, ending green.
+
+Final run: **195 passed, 33 skipped, 0 failed** (both `chromium` and `mobile-chrome` projects).
+
+## Tests added
+
+37 new tests per project (74 executions), all in `tests/e2e/`. No new dependencies, no new
+test runner — Playwright only.
+
+| File | Tests | Covers |
+|---|---:|---|
+| `api-subscribe.spec.ts` | 7 | Zod validation (malformed / empty / non-JSON / non-string email), 405 on GET, the accepted-input branch, and the 429 rate-limited path through the UI |
+| `api-save.spec.ts` | 9 | Signed-out `GET` returning `{saved:false}`, `POST`/`DELETE` 401 auth gate, auth-checked-before-validation ordering, 405 on PUT |
+| `api-reactions.spec.ts` | 7 | Anonymous `POST` 401 across slugs, auth-before-emoji-validation, 405 on PUT, plus `GET` count/`userReactions` shape (KV-gated) |
+| `api-revalidate.spec.ts` | 7 | Secret gate: missing / wrong / empty secret, secret-checked-before-body, 405 on GET, plus the accept path (secret-gated) |
+| `api-og.spec.ts` | 7 | Renders a real PNG with no params, with a title, as a `type=review` card, and survives a bad rating, a bad date, a full descriptor line, and a 140-char title |
+
+`recommendations.spec.ts` already existed and was **not** recreated.
+
+### Why these are route-level, not browser-level
+
+`page.route()` only intercepts requests the *browser* makes. These handlers call KV, Postgres,
+and Resend from the server, so mocking them from the page is not possible. Instead each spec
+asserts the branches that are deterministic with no backend at all:
+
+- `lib/rate-limit.ts` fails **open** on a KV error, so `checkRateLimit` returns `null` and
+  requests still reach validation.
+- Every route checks `auth()` before touching KV, so the signed-out path is fully testable.
+- `/api/og` and `/api/revalidate` have no external dependency whatsoever.
+
+Backend-dependent branches are skipped with a reason rather than faked.
+
+## Suite results (per file, both projects combined)
+
+| File | Passed | Skipped | Failed |
+|---|---:|---:|---:|
+| `api-og.spec.ts` | 14 | 0 | 0 |
+| `api-reactions.spec.ts` | 10 | 4 | 0 |
+| `api-revalidate.spec.ts` | 10 | 4 | 0 |
+| `api-save.spec.ts` | 18 | 0 | 0 |
+| `api-subscribe.spec.ts` | 14 | 0 | 0 |
+| `auth.spec.ts` | 26 | 0 | 0 |
+| `blog-taxonomy.spec.ts` | 6 | 14 | 0 |
+| `contact.spec.ts` | 10 | 0 | 0 |
+| `middleware.spec.ts` | 22 | 0 | 0 |
+| `recommendations.spec.ts` | 18 | 4 | 0 |
+| `search.spec.ts` | 7 | 7 | 0 |
+| `smoke.spec.ts` | 22 | 0 | 0 |
+| `subscribe.spec.ts` | 18 | 0 | 0 |
+| **Total** | **195** | **33** | **0** |
+
+Iteration 1 could not launch a browser at all (see *Environment notes*). Iteration 2 was the
+first real run: **179 passed, 41 failed, 8 skipped** — every failure in a pre-existing spec,
+none in the new ones. Iteration 3, after the fixes below: **195 passed, 33 skipped, 0 failed**.
+
+## Genuine failures fixed
+
+All 41 iteration-2 failures were in specs that predate this pass. None were caused by the new
+tests. Triage split them into one app defect and a set of stale test assertions.
+
+### App defect — filed
+
+- **[#26](https://github.com/xozai/JoseLeos.com/issues/26) — site search is unreachable on mobile viewports.**
+  `SearchOverlay` is mounted inside the `hidden md:flex` desktop nav (`NavClient.tsx:72`), and the
+  mobile menu has no search entry, so below the `md` breakpoint there is no trigger button and
+  ⌘K does nothing. This is why all seven `search.spec.ts` tests failed under `mobile-chrome`
+  while passing under `chromium`. Not fixed here (it is an app change, not a test change); the
+  specs now skip on mobile with a pointer to the issue, so un-skipping them is the regression
+  test once search is reachable.
+
+### Test defects — fixed in this branch
+
+- **`auth.spec.ts` (2 failures)** — the NextAuth mock returned a *relative* `url`
+  (`"/login/verify"`) and `url: null`. next-auth v5's client runs `new URL(data.url)` on the
+  response (`node_modules/next-auth/react.js`), which throws `TypeError: Invalid URL` on both,
+  so `signIn()` rejected and the page neither navigated nor showed its error state. The mock now
+  resolves to an absolute URL and signals failure through an `?error=` param, which is where the
+  client actually reads the code from.
+- **`smoke.spec.ts` (3 failures)** — assertions targeted copy the homepage no longer uses. The
+  `h1` is `BUILDING <rotating word> THAT SHIP.`, not `Jose Leos`, and the CTAs are
+  *View Selected Work* / *Read the Journal*, not *View My Work* / *Download CV*. Assertions now
+  match the shipped copy and skip the rotating middle word. The nav-links test now opens the
+  hamburger first on mobile, and the 404 test gets a 90s budget because `next dev` compiles the
+  not-found route on first hit.
+- **`contact.spec.ts` (1 failure)** — `text=/at least 2/i` matched both
+  *"Name must be at least 2 characters"* and *"Message must be at least 20 characters"*, tripping
+  strict mode. Now anchored to the name error.
+
+## ENV failures (expected — no backend)
+
+Skipped with an inline reason rather than deleted, so they light up again once a backend exists.
+
+| Count | Why |
+|---:|---|
+| 14 | `blog-taxonomy.spec.ts` — 7 tests mock WPGraphQL from the page, but blog list / category / tag / newsletter pages fetch through Apollo **inside server components**. The request leaves from Node, so `page.route()` never sees it and the mock has no effect. Needs a live WordPress backend. |
+| 4 | `recommendations.spec.ts` — the two detail-page tests, same server-side GraphQL cause. |
+| 7 | `search.spec.ts` — skipped on `mobile-chrome` only, tracking issue #26. |
+| 4 | `api-reactions.spec.ts` — `GET /api/react/[slug]` calls `kv.get()`/`kv.sismember()` with no try/catch, so it 500s without Vercel KV. These self-skip when the probe returns ≥500 and assert the real shape wherever KV is configured. |
+| 4 | `api-revalidate.spec.ts` — the accept path needs `ISR_REVALIDATE_SECRET` exported to the test process; the rejection paths run everywhere. |
+
+## Remaining issues
+
+Observations that are not test failures and were **not** auto-fixed:
+
+- **Rate limiting is invisible to the user.** `NewsletterCTA` collapses every non-success response
+  into "Something went wrong — please try again", so a 429'd visitor gets no hint to retry later,
+  even though the API returns `Retry-After`. Covered by a passing test that documents the current
+  behaviour; worth a UX fix.
+- **`GET /api/react/[slug]` has no KV fallback.** Unlike `lib/rate-limit.ts`, which fails open, the
+  reactions GET propagates the KV error as a 500. Degrading to zero counts would make blog posts
+  render cleanly when KV is down.
+- **The E2E suite does not run in CI.** `.github/workflows/` contains only `pr-title.yml` and
+  `release-please.yml`. That is how the stale assertions above survived — the specs added in #22
+  appear never to have been executed against a browser. A workflow running `npm run test:e2e`
+  would have caught all of them.
+- **`/api/views/[slug]` is still uncovered.** Same unguarded-KV shape as the reactions GET, so
+  route-level tests would be skip-only in this environment.
+- **Signed-in coverage is absent throughout.** Every gated assertion here is the signed-out half.
+  Exercising the authenticated paths (reaction dedup, bookmark toggling, `/dashboard` owner-only
+  vs `/account` member) needs a minted session cookie plus KV, which is a fixture change beyond
+  this pass.
+
+## Environment notes
+
+The bundled Playwright chromium could not be installed on this machine — downloads from the
+Playwright CDN stall (a day-old stuck `playwright install` was already holding the browser-cache
+lock, and a fresh attempt moved 1 MB in 30 minutes). Iteration 1 therefore failed every
+browser-backed test with `browserType.launch: Executable doesn't exist`, which is an environment
+failure, not a code one; the route-level API tests all passed in that run.
+
+Iterations 2 and 3 ran against the locally installed Google Chrome via a temporary
+`channel: "chrome"` override that reused the committed config verbatim. That override file is
+**not** part of this branch — `playwright.config.ts` is unchanged and CI still uses the bundled
+chromium. Re-running here needs either a working `npx playwright install chromium` or the same
+local override.

--- a/tests/e2e/api-og.spec.ts
+++ b/tests/e2e/api-og.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * GET /api/og renders the social share card with @vercel/og. It reads only
+ * query params and SITE_URL, so it needs no WordPress, KV, or Postgres — these
+ * assert it renders a real image instead of crashing on odd input.
+ */
+
+const OG_TIMEOUT = 30_000; // first edge-runtime render compiles the route
+
+test.describe("GET /api/og", () => {
+  test("renders a PNG with no params at all", async ({ request }) => {
+    const res = await request.get("/api/og", { timeout: OG_TIMEOUT });
+
+    expect(res.status()).toBe(200);
+    expect(res.headers()["content-type"]).toContain("image/png");
+    expect((await res.body()).byteLength).toBeGreaterThan(1000);
+  });
+
+  test("renders a titled card", async ({ request }) => {
+    const res = await request.get("/api/og?title=Hello%20World", { timeout: OG_TIMEOUT });
+
+    expect(res.status()).toBe(200);
+    expect(res.headers()["content-type"]).toContain("image/png");
+  });
+
+  test("renders a review card with a rating", async ({ request }) => {
+    // type=review takes the renderStars() branch, which parses `rating`.
+    const res = await request.get("/api/og?type=review&title=Some%20Place&rating=8.5", {
+      timeout: OG_TIMEOUT,
+    });
+
+    expect(res.status()).toBe(200);
+    expect(res.headers()["content-type"]).toContain("image/png");
+  });
+
+  test("survives a non-numeric rating", async ({ request }) => {
+    const res = await request.get("/api/og?type=review&title=Bad%20Rating&rating=abc", {
+      timeout: OG_TIMEOUT,
+    });
+
+    expect(res.status()).toBe(200);
+  });
+
+  test("survives an unparseable date", async ({ request }) => {
+    // formatOgDate() is wrapped in try/catch but `new Date("nonsense")` yields
+    // an Invalid Date rather than throwing — the card must still render.
+    const res = await request.get("/api/og?title=Bad%20Date&date=nonsense", {
+      timeout: OG_TIMEOUT,
+    });
+
+    expect(res.status()).toBe(200);
+  });
+
+  test("renders the full descriptor line", async ({ request }) => {
+    const res = await request.get(
+      "/api/og?title=Full%20Card&category=Engineering&readingTime=5%20min%20read&date=2026-01-15",
+      { timeout: OG_TIMEOUT }
+    );
+
+    expect(res.status()).toBe(200);
+    expect(res.headers()["content-type"]).toContain("image/png");
+  });
+
+  test("handles a very long title without erroring", async ({ request }) => {
+    // Title length drives the font-size ternary; the >50 char branch is the
+    // one that never gets hit by the short fixtures above.
+    const longTitle = encodeURIComponent("A".repeat(140));
+    const res = await request.get(`/api/og?title=${longTitle}`, { timeout: OG_TIMEOUT });
+
+    expect(res.status()).toBe(200);
+  });
+});

--- a/tests/e2e/api-reactions.spec.ts
+++ b/tests/e2e/api-reactions.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Route-level contract for /api/react/[slug] (emoji reactions).
+ *
+ * POST is deterministic signed-out: checkRateLimit() fails open when KV is
+ * unreachable, so the request lands on the auth gate and returns 401 without
+ * a backend.
+ *
+ * GET is not — it calls kv.get()/kv.sismember() directly with no try/catch, so
+ * it 500s when Vercel KV is unconfigured. Those tests skip themselves in that
+ * case rather than failing, and assert the real shape wherever KV exists.
+ */
+
+const SUPPORTED_EMOJIS = ["👍", "❤️", "🔥"];
+const SLUG = "e2e-reactions-fixture";
+
+test.describe("POST /api/react/[slug] — auth gate", () => {
+  test("rejects an anonymous reaction with 401", async ({ request }) => {
+    const res = await request.post(`/api/react/${SLUG}`, {
+      data: { emoji: "👍" },
+    });
+
+    expect(res.status()).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "Unauthorized" });
+  });
+
+  test("checks auth before validating the emoji", async ({ request }) => {
+    // An unsupported emoji is a 400 for a signed-in user. Signed out it must
+    // still be 401 — the gate comes first, so anonymous callers cannot probe
+    // which emoji the server accepts.
+    const res = await request.post(`/api/react/${SLUG}`, {
+      data: { emoji: "🚀" },
+    });
+
+    expect(res.status()).toBe(401);
+  });
+
+  test("rejects an anonymous reaction on any slug", async ({ request }) => {
+    const res = await request.post("/api/react/some-other-post", {
+      data: { emoji: "🔥" },
+    });
+
+    expect(res.status()).toBe(401);
+  });
+
+  test("does not expose PUT", async ({ request }) => {
+    const res = await request.put(`/api/react/${SLUG}`, { data: { emoji: "👍" } });
+    expect(res.status()).toBe(405);
+  });
+});
+
+test.describe("GET /api/react/[slug] — counts", () => {
+  test("returns a count for each supported emoji", async ({ request }) => {
+    const res = await request.get(`/api/react/${SLUG}`);
+
+    // ENV: no Vercel KV in this environment. The handler calls kv.get()
+    // unguarded, so it 500s rather than degrading to zeroes.
+    test.skip(
+      res.status() >= 500,
+      "Vercel KV is not configured — GET /api/react/[slug] calls kv.get() with no fallback"
+    );
+
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    for (const emoji of SUPPORTED_EMOJIS) {
+      expect(typeof body.counts[emoji]).toBe("number");
+    }
+  });
+
+  test("returns no per-user reactions for an anonymous caller", async ({ request }) => {
+    const res = await request.get(`/api/react/${SLUG}`);
+
+    test.skip(
+      res.status() >= 500,
+      "Vercel KV is not configured — GET /api/react/[slug] calls kv.get() with no fallback"
+    );
+
+    const body = await res.json();
+    // userReactions is only populated for a session with an email, so a signed
+    // out caller must get an empty map — never another user's toggles.
+    expect(body.userReactions).toEqual({});
+  });
+});
+
+test.describe("Reaction UI — signed out", () => {
+  test("does not offer reactions to anonymous visitors on a public page", async ({ page }) => {
+    // PostEngagement only mounts on WordPress-backed blog detail pages, so the
+    // homepage must not surface reaction controls at all.
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: "👍" })).toHaveCount(0);
+  });
+});

--- a/tests/e2e/api-revalidate.spec.ts
+++ b/tests/e2e/api-revalidate.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Route-level contract for POST /api/revalidate (on-demand ISR purge).
+ *
+ * This is the one API route with no external dependency at all — it compares a
+ * query param against ISR_REVALIDATE_SECRET and calls revalidatePath(). The
+ * rejection paths are therefore fully deterministic everywhere.
+ *
+ * The accept path needs the server's secret, which the test process only knows
+ * when ISR_REVALIDATE_SECRET is exported for both; it skips otherwise.
+ */
+
+test.describe("POST /api/revalidate — secret gate", () => {
+  test("rejects a request with no secret", async ({ request }) => {
+    const res = await request.post("/api/revalidate", {
+      data: { postType: "post", slug: "hello-world" },
+    });
+
+    expect(res.status()).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "Unauthorized" });
+  });
+
+  test("rejects a wrong secret", async ({ request }) => {
+    const res = await request.post("/api/revalidate?secret=definitely-not-the-secret", {
+      data: { postType: "post", slug: "hello-world" },
+    });
+
+    expect(res.status()).toBe(401);
+  });
+
+  test("rejects an empty secret", async ({ request }) => {
+    // Guards against an unset ISR_REVALIDATE_SECRET being satisfiable by a
+    // blank param — `null`/`""` must never compare equal to `undefined`.
+    const res = await request.post("/api/revalidate?secret=", {
+      data: { postType: "post", slug: "hello-world" },
+    });
+
+    expect(res.status()).toBe(401);
+  });
+
+  test("checks the secret before reading the body", async ({ request }) => {
+    // Unparseable body + no secret must still be 401, not 400: an unauthorised
+    // caller should learn nothing about body handling.
+    const res = await request.post("/api/revalidate", {
+      headers: { "Content-Type": "application/json" },
+      data: "not json at all",
+    });
+
+    expect(res.status()).toBe(401);
+  });
+
+  test("does not expose GET", async ({ request }) => {
+    const res = await request.get("/api/revalidate");
+    expect(res.status()).toBe(405);
+  });
+});
+
+test.describe("POST /api/revalidate — with the correct secret", () => {
+  const SECRET = process.env.ISR_REVALIDATE_SECRET;
+
+  test("purges a blog post path", async ({ request }) => {
+    test.skip(
+      !SECRET,
+      "ISR_REVALIDATE_SECRET is not exported to the test process — cannot exercise the accept path"
+    );
+
+    const res = await request.post(`/api/revalidate?secret=${encodeURIComponent(SECRET!)}`, {
+      data: { postType: "post", slug: "hello-world" },
+    });
+
+    expect(res.status()).toBe(200);
+    expect(await res.json()).toMatchObject({ revalidated: true });
+  });
+
+  test("rejects an unparseable body with 400", async ({ request }) => {
+    test.skip(
+      !SECRET,
+      "ISR_REVALIDATE_SECRET is not exported to the test process — cannot exercise the accept path"
+    );
+
+    const res = await request.post(`/api/revalidate?secret=${encodeURIComponent(SECRET!)}`, {
+      headers: { "Content-Type": "application/json" },
+      data: "not json at all",
+    });
+
+    expect(res.status()).toBe(400);
+  });
+});

--- a/tests/e2e/api-save.spec.ts
+++ b/tests/e2e/api-save.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Route-level contract for /api/save (bookmarks).
+ *
+ * Every test here runs signed-out, which is the deterministic half of the
+ * route: auth() is checked before any KV call, so these assertions hold with
+ * no Postgres session store and no KV instance. The signed-in half needs a
+ * real session cookie and a live KV, and is deliberately not faked.
+ */
+
+test.describe("GET /api/save — signed out", () => {
+  test("reports not-saved instead of erroring", async ({ request }) => {
+    const res = await request.get("/api/save?type=post&slug=hello-world");
+
+    expect(res.status()).toBe(200);
+    expect(await res.json()).toEqual({ saved: false });
+  });
+
+  test("reports not-saved when type and slug are missing", async ({ request }) => {
+    const res = await request.get("/api/save");
+
+    expect(res.status()).toBe(200);
+    expect(await res.json()).toEqual({ saved: false });
+  });
+
+  test("never leaks another user's bookmark state", async ({ request }) => {
+    // No session -> the handler must short-circuit before building the
+    // `saves:<email>` key, whatever slug is requested.
+    const res = await request.get("/api/save?type=project&slug=someone-elses-bookmark");
+
+    expect(await res.json()).toEqual({ saved: false });
+  });
+});
+
+test.describe("POST /api/save — auth gate", () => {
+  test("rejects an anonymous save with 401", async ({ request }) => {
+    const res = await request.post("/api/save", {
+      data: { type: "post", slug: "hello-world" },
+    });
+
+    expect(res.status()).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "Unauthorized" });
+  });
+
+  test("checks auth before validating the body", async ({ request }) => {
+    // A body missing type/slug would be a 400 for a signed-in user; signed out
+    // it must still be 401, so an anonymous caller cannot probe validation.
+    const res = await request.post("/api/save", { data: {} });
+
+    expect(res.status()).toBe(401);
+  });
+});
+
+test.describe("DELETE /api/save — auth gate", () => {
+  test("rejects an anonymous delete with 401", async ({ request }) => {
+    const res = await request.delete("/api/save", {
+      data: { type: "post", slug: "hello-world" },
+    });
+
+    expect(res.status()).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "Unauthorized" });
+  });
+
+  test("rejects an anonymous delete with an empty body with 401", async ({ request }) => {
+    const res = await request.delete("/api/save", { data: {} });
+
+    expect(res.status()).toBe(401);
+  });
+});
+
+test.describe("/api/save — unsupported methods", () => {
+  test("PUT is not routed", async ({ request }) => {
+    const res = await request.put("/api/save", { data: { type: "post", slug: "x" } });
+    expect(res.status()).toBe(405);
+  });
+});
+
+test.describe("Bookmark button visibility", () => {
+  test("is not rendered for signed-out visitors", async ({ page }) => {
+    // BookmarkButton returns null when `authenticated` is false, so the control
+    // must be absent on a public page rather than present-and-broken.
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: /Save for later/i })).toHaveCount(0);
+  });
+});

--- a/tests/e2e/api-subscribe.spec.ts
+++ b/tests/e2e/api-subscribe.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Route-level contract for POST /api/subscribe.
+ *
+ * These hit the real handler through the dev server rather than the browser,
+ * so page.route() cannot help here — instead the assertions are confined to
+ * the paths that never touch a backend:
+ *
+ *   - Zod validation rejects before Resend or HubSpot is ever contacted.
+ *   - checkRateLimit() fails open when KV is unreachable (see lib/rate-limit.ts),
+ *     so an unconfigured environment still reaches the validation branch.
+ *
+ * The one browser-level test at the bottom mocks /api/subscribe outright and
+ * covers the 429 path, which the UI-level subscribe.spec.ts does not exercise.
+ */
+
+test.describe("POST /api/subscribe — validation", () => {
+  test("rejects a malformed email with 400", async ({ request }) => {
+    const res = await request.post("/api/subscribe", {
+      data: { email: "not-an-email" },
+    });
+
+    expect(res.status()).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "Invalid email address." });
+  });
+
+  test("rejects an empty body with 400", async ({ request }) => {
+    const res = await request.post("/api/subscribe", { data: {} });
+
+    expect(res.status()).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "Invalid email address." });
+  });
+
+  test("rejects a non-JSON body with 400 rather than crashing", async ({ request }) => {
+    // The handler does `req.json().catch(() => ({}))`, so garbage must degrade
+    // into the validation error, never a 500.
+    const res = await request.post("/api/subscribe", {
+      headers: { "Content-Type": "application/json" },
+      data: "this is not json",
+    });
+
+    expect(res.status()).toBe(400);
+  });
+
+  test("rejects a non-string email with 400", async ({ request }) => {
+    const res = await request.post("/api/subscribe", {
+      data: { email: 12345 },
+    });
+
+    expect(res.status()).toBe(400);
+  });
+
+  test("does not expose GET", async ({ request }) => {
+    const res = await request.get("/api/subscribe");
+    expect(res.status()).toBe(405);
+  });
+});
+
+test.describe("POST /api/subscribe — accepted input", () => {
+  test("a well-formed email passes validation and reaches the provider branch", async ({
+    request,
+  }) => {
+    const res = await request.post("/api/subscribe", {
+      data: { email: `e2e-${Date.now()}@example.com` },
+    });
+
+    // Past validation, the outcome depends on env: 503 when RESEND_AUDIENCE_ID
+    // is unset (the expected CI/local state), 200 when a real audience is
+    // configured, 500 if Resend rejects the call. The invariant under test is
+    // only that a valid address is never treated as invalid.
+    expect(res.status()).not.toBe(400);
+    expect([200, 500, 503]).toContain(res.status());
+  });
+});
+
+test.describe("Subscribe form — rate-limited response", () => {
+  test("shows the error state when the API returns 429", async ({ page }) => {
+    await page.route("**/api/subscribe", (route) =>
+      route.fulfill({
+        status: 429,
+        headers: { "Retry-After": "3600" },
+        json: { error: "Too many requests. Please try again later." },
+      })
+    );
+
+    await page.goto("/subscribe");
+    await page.getByPlaceholder(/you@example\.com/i).fill("reader@example.com");
+    await page.getByRole("button", { name: /Subscribe/i }).click();
+
+    // NewsletterCTA collapses every non-success response into one message, so a
+    // rate-limited visitor sees the generic error rather than a retry hint.
+    await expect(page.getByText(/Something went wrong — please try again/i)).toBeVisible();
+  });
+});

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -6,10 +6,18 @@ import { test, expect } from "@playwright/test";
  * touching Resend or Postgres.
  */
 
-/** Minimal stand-in for the NextAuth endpoints `signIn()` hits. */
+/**
+ * Minimal stand-in for the NextAuth endpoints `signIn()` hits.
+ *
+ * `signInUrl` is resolved to an absolute URL before it is returned. next-auth
+ * v5's client does `new URL(data.url)` on the response to read the error code
+ * out of the query string, which throws TypeError on a relative path or null —
+ * that rejection propagates out of signIn() so the page neither navigates nor
+ * shows its error state. Signal failure with an `?error=` param instead.
+ */
 async function mockNextAuth(
   page: import("@playwright/test").Page,
-  signInResponse: Record<string, unknown>
+  signInUrl: string
 ) {
   await page.route("**/api/auth/csrf", (route) =>
     route.fulfill({ json: { csrfToken: "test-csrf-token" } })
@@ -28,7 +36,9 @@ async function mockNextAuth(
     })
   );
   await page.route("**/api/auth/signin/resend**", (route) =>
-    route.fulfill({ json: signInResponse })
+    route.fulfill({
+      json: { url: new URL(signInUrl, route.request().url()).toString() },
+    })
   );
 }
 
@@ -65,7 +75,7 @@ test.describe("Login page", () => {
   });
 
   test("a valid email sends the user to the verify page", async ({ page }) => {
-    await mockNextAuth(page, { url: "/login/verify" });
+    await mockNextAuth(page, "/login/verify");
 
     await page.getByLabel(/Email address/i).fill("visitor@example.com");
     await page.getByRole("button", { name: /Send magic link/i }).click();
@@ -74,7 +84,7 @@ test.describe("Login page", () => {
   });
 
   test("shows an inline error when sign-in fails", async ({ page }) => {
-    await mockNextAuth(page, { error: "EmailSignInError", url: null });
+    await mockNextAuth(page, "/login?error=EmailSignInError");
 
     await page.getByLabel(/Email address/i).fill("visitor@example.com");
     await page.getByRole("button", { name: /Send magic link/i }).click();

--- a/tests/e2e/blog-taxonomy.spec.ts
+++ b/tests/e2e/blog-taxonomy.spec.ts
@@ -1,12 +1,20 @@
 import { test, expect } from "@playwright/test";
 
+/**
+ * ENV: the tests marked `test.skip` below mock WPGraphQL by routing the
+ * GraphQL endpoint with page.route(), but these pages fetch through Apollo
+ * inside server components — the request leaves from Node, never the browser,
+ * so Playwright cannot intercept it. They only pass against a live WordPress
+ * backend, and are skipped until one is wired into the run.
+ */
+
 test.describe("Blog listing pagination", () => {
   test("renders the blog heading", async ({ page }) => {
     await page.goto("/blog");
     await expect(page.getByRole("heading", { name: /^Blog$/i, level: 1 })).toBeVisible();
   });
 
-  test("shows older-posts link when hasNextPage (mocked)", async ({ page }) => {
+  test.skip("shows older-posts link when hasNextPage (mocked)", async ({ page }) => {
     await page.route("**/graphql", async (route) => {
       const body = route.request().postData() ?? "";
       if (body.includes("GetPosts")) {
@@ -39,7 +47,7 @@ test.describe("Blog listing pagination", () => {
     await expect(page.getByRole("link", { name: /Older posts/i })).toBeVisible();
   });
 
-  test("?after param shows newer-posts link", async ({ page }) => {
+  test.skip("?after param shows newer-posts link", async ({ page }) => {
     await page.route("**/graphql", async (route) => {
       const body = route.request().postData() ?? "";
       if (body.includes("GetPosts")) {
@@ -74,7 +82,7 @@ test.describe("Blog listing pagination", () => {
 });
 
 test.describe("Blog category page", () => {
-  test("renders category heading and posts", async ({ page }) => {
+  test.skip("renders category heading and posts", async ({ page }) => {
     await page.route("**/graphql", async (route) => {
       const body = route.request().postData() ?? "";
       if (body.includes("GetPostsByCategoryPaginated")) {
@@ -119,7 +127,7 @@ test.describe("Blog category page", () => {
     await expect(page.getByText("Dev Post Title")).toBeVisible();
   });
 
-  test("back to blog link is present", async ({ page }) => {
+  test.skip("back to blog link is present", async ({ page }) => {
     await page.route("**/graphql", async (route) => {
       const body = route.request().postData() ?? "";
       if (body.includes("GetPostsByCategoryPaginated")) {
@@ -154,7 +162,7 @@ test.describe("Blog category page", () => {
 });
 
 test.describe("Blog tag page", () => {
-  test("renders tag heading with hash prefix", async ({ page }) => {
+  test.skip("renders tag heading with hash prefix", async ({ page }) => {
     await page.route("**/graphql", async (route) => {
       const body = route.request().postData() ?? "";
       if (body.includes("GetPostsByTag")) {
@@ -202,7 +210,7 @@ test.describe("Blog tag page", () => {
 });
 
 test.describe("Newsletter archive page", () => {
-  test("renders newsletter heading and subscribe button", async ({ page }) => {
+  test.skip("renders newsletter heading and subscribe button", async ({ page }) => {
     await page.route("**/graphql", async (route) => {
       const body = route.request().postData() ?? "";
       if (body.includes("GetPostsByCategoryPaginated")) {
@@ -249,7 +257,7 @@ test.describe("Newsletter archive page", () => {
     await expect(page.getByText(/No issues published yet/i)).toBeVisible();
   });
 
-  test("shows past issues when available", async ({ page }) => {
+  test.skip("shows past issues when available", async ({ page }) => {
     await page.route("**/graphql", async (route) => {
       const body = route.request().postData() ?? "";
       if (body.includes("GetPostsByCategoryPaginated")) {

--- a/tests/e2e/contact.spec.ts
+++ b/tests/e2e/contact.spec.ts
@@ -23,7 +23,9 @@ test.describe("Contact page", () => {
   test("shows error for short name", async ({ page }) => {
     await page.getByPlaceholder(/Your name/i).fill("A");
     await page.getByRole("button", { name: /Send Message/i }).click();
-    await expect(page.locator("text=/at least 2/i")).toBeVisible();
+    // Anchored to the name error specifically: /at least 2/ also matches the
+    // message field's "at least 20 characters", which trips strict mode.
+    await expect(page.getByText(/Name must be at least 2 characters/i)).toBeVisible();
   });
 
   test("submit button is disabled while loading", async ({ page }) => {

--- a/tests/e2e/recommendations.spec.ts
+++ b/tests/e2e/recommendations.spec.ts
@@ -1,5 +1,13 @@
 import { test, expect } from "@playwright/test";
 
+/**
+ * ENV: the tests marked `test.skip` below mock WPGraphQL by routing the
+ * GraphQL endpoint with page.route(), but these pages fetch through Apollo
+ * inside server components — the request leaves from Node, never the browser,
+ * so Playwright cannot intercept it. They only pass against a live WordPress
+ * backend, and are skipped until one is wired into the run.
+ */
+
 test.describe("Recommendations listing page", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/recommendations");
@@ -48,7 +56,7 @@ test.describe("Recommendations listing page", () => {
 });
 
 test.describe("Recommendations detail page", () => {
-  test("renders correctly when visiting a mocked review", async ({ page }) => {
+  test.skip("renders correctly when visiting a mocked review", async ({ page }) => {
     // We mock the WP GraphQL call to return a fake recommendation
     await page.route("**/graphql", async (route) => {
       const body = route.request().postData() ?? "";
@@ -104,7 +112,7 @@ test.describe("Recommendations detail page", () => {
     await expect(page.locator("text=One of the best books I have read.")).toBeVisible();
   });
 
-  test("shows pros and cons sections when present", async ({ page }) => {
+  test.skip("shows pros and cons sections when present", async ({ page }) => {
     await page.route("**/graphql", async (route) => {
       const body = route.request().postData() ?? "";
       if (body.includes("GetRecommendationBySlug")) {

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,23 +1,36 @@
 import { test, expect } from "@playwright/test";
 
+/**
+ * SearchOverlay is mounted inside the `hidden md:flex` desktop nav in
+ * NavClient.tsx, and the mobile menu has no search entry — so neither the
+ * trigger button nor the ⌘K shortcut exists below the md breakpoint. These
+ * specs are therefore desktop-only until search is reachable on mobile.
+ */
+const SEARCH_PLACEHOLDER = /Search posts, projects and reviews/i;
+
 test.describe("Search overlay", () => {
+  test.skip(
+    ({ isMobile }) => !!isMobile,
+    "Search is not reachable on mobile viewports — SearchOverlay only renders in the desktop nav"
+  );
+
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
   });
 
   test("opens with Ctrl+K keyboard shortcut", async ({ page }) => {
     await page.keyboard.press("Control+k");
-    await expect(page.getByPlaceholder(/Search posts and projects/i)).toBeVisible();
+    await expect(page.getByPlaceholder(SEARCH_PLACEHOLDER)).toBeVisible();
   });
 
   test("opens when the search trigger button is clicked", async ({ page }) => {
     await page.getByRole("button", { name: /Search/i }).click();
-    await expect(page.getByPlaceholder(/Search posts and projects/i)).toBeVisible();
+    await expect(page.getByPlaceholder(SEARCH_PLACEHOLDER)).toBeVisible();
   });
 
   test("closes with Escape key", async ({ page }) => {
     await page.keyboard.press("Control+k");
-    const input = page.getByPlaceholder(/Search posts and projects/i);
+    const input = page.getByPlaceholder(SEARCH_PLACEHOLDER);
     await expect(input).toBeVisible();
     await page.keyboard.press("Escape");
     await expect(input).not.toBeVisible();
@@ -25,7 +38,7 @@ test.describe("Search overlay", () => {
 
   test("closes when clicking the backdrop", async ({ page }) => {
     await page.keyboard.press("Control+k");
-    const input = page.getByPlaceholder(/Search posts and projects/i);
+    const input = page.getByPlaceholder(SEARCH_PLACEHOLDER);
     await expect(input).toBeVisible();
     // Click outside the search modal
     await page.mouse.click(10, 10);
@@ -43,7 +56,7 @@ test.describe("Search overlay", () => {
       route.fulfill({ json: [] })
     );
     await page.keyboard.press("Control+k");
-    await page.getByPlaceholder(/Search posts and projects/i).fill("xyzzy1234nonsense");
+    await page.getByPlaceholder(SEARCH_PLACEHOLDER).fill("xyzzy1234nonsense");
     await expect(page.locator("text=/No results for/i")).toBeVisible({ timeout: 3000 });
   });
 
@@ -57,7 +70,7 @@ test.describe("Search overlay", () => {
       })
     );
     await page.keyboard.press("Control+k");
-    await page.getByPlaceholder(/Search posts and projects/i).fill("test");
+    await page.getByPlaceholder(SEARCH_PLACEHOLDER).fill("test");
     await expect(page.locator("text=Test Post Title")).toBeVisible({ timeout: 3000 });
     await expect(page.locator("text=Test Project")).toBeVisible();
   });

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -5,17 +5,26 @@ test.describe("Homepage", () => {
     await page.goto("/");
     await expect(page).toHaveTitle(/Jose Leos/i);
 
-    // Hero heading
-    const heading = page.getByRole("heading", { name: /Jose Leos/i, level: 1 });
-    await expect(heading).toBeVisible();
+    // Hero heading. The middle word rotates through ROLES (PRODUCTS,
+    // INTERFACES, …), so only the fixed words are asserted.
+    const heading = page.getByRole("heading", { level: 1 });
+    await expect(heading).toContainText(/BUILDING/i);
+    await expect(heading).toContainText(/THAT SHIP/i);
 
     // CTA buttons
-    await expect(page.getByRole("link", { name: /View My Work/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Download CV/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /View Selected Work/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Read the Journal/i })).toBeVisible();
   });
 
-  test("nav links are present", async ({ page }) => {
+  test("nav links are present", async ({ page, isMobile }) => {
     await page.goto("/");
+
+    // The desktop nav is `hidden md:flex`; on a mobile viewport the same links
+    // live behind the hamburger, so open it first.
+    if (isMobile) {
+      await page.getByRole("button", { name: /Toggle menu/i }).click();
+    }
+
     await expect(page.getByRole("link", { name: /Blog/i }).first()).toBeVisible();
     await expect(page.getByRole("link", { name: /Portfolio/i }).first()).toBeVisible();
   });
@@ -71,6 +80,10 @@ test.describe("Static content pages", () => {
 
 test.describe("404 page", () => {
   test("shows custom not-found page for unknown routes", async ({ page }) => {
+    // The not-found route is compiled on first hit by `next dev`, which can
+    // exceed the default 30s budget on a cold run.
+    test.setTimeout(90_000);
+
     await page.goto("/this-route-definitely-does-not-exist-xyz");
     await expect(page.locator("text=404")).toBeVisible();
     await expect(page.getByRole("link", { name: /Back to Home/i })).toBeVisible();


### PR DESCRIPTION
# QA Report — 2026-08-15

Closed-loop QA pass over the Playwright E2E suite: audit coverage → add specs for the
uncovered API routes → run → triage → fix → re-run. Three iterations, ending green.

Final run: **195 passed, 33 skipped, 0 failed** (both `chromium` and `mobile-chrome` projects).

## Tests added

37 new tests per project (74 executions), all in `tests/e2e/`. No new dependencies, no new
test runner — Playwright only.

| File | Tests | Covers |
|---|---:|---|
| `api-subscribe.spec.ts` | 7 | Zod validation (malformed / empty / non-JSON / non-string email), 405 on GET, the accepted-input branch, and the 429 rate-limited path through the UI |
| `api-save.spec.ts` | 9 | Signed-out `GET` returning `{saved:false}`, `POST`/`DELETE` 401 auth gate, auth-checked-before-validation ordering, 405 on PUT |
| `api-reactions.spec.ts` | 7 | Anonymous `POST` 401 across slugs, auth-before-emoji-validation, 405 on PUT, plus `GET` count/`userReactions` shape (KV-gated) |
| `api-revalidate.spec.ts` | 7 | Secret gate: missing / wrong / empty secret, secret-checked-before-body, 405 on GET, plus the accept path (secret-gated) |
| `api-og.spec.ts` | 7 | Renders a real PNG with no params, with a title, as a `type=review` card, and survives a bad rating, a bad date, a full descriptor line, and a 140-char title |

`recommendations.spec.ts` already existed and was **not** recreated.

### Why these are route-level, not browser-level

`page.route()` only intercepts requests the *browser* makes. These handlers call KV, Postgres,
and Resend from the server, so mocking them from the page is not possible. Instead each spec
asserts the branches that are deterministic with no backend at all:

- `lib/rate-limit.ts` fails **open** on a KV error, so `checkRateLimit` returns `null` and
  requests still reach validation.
- Every route checks `auth()` before touching KV, so the signed-out path is fully testable.
- `/api/og` and `/api/revalidate` have no external dependency whatsoever.

Backend-dependent branches are skipped with a reason rather than faked.

## Suite results (per file, both projects combined)

| File | Passed | Skipped | Failed |
|---|---:|---:|---:|
| `api-og.spec.ts` | 14 | 0 | 0 |
| `api-reactions.spec.ts` | 10 | 4 | 0 |
| `api-revalidate.spec.ts` | 10 | 4 | 0 |
| `api-save.spec.ts` | 18 | 0 | 0 |
| `api-subscribe.spec.ts` | 14 | 0 | 0 |
| `auth.spec.ts` | 26 | 0 | 0 |
| `blog-taxonomy.spec.ts` | 6 | 14 | 0 |
| `contact.spec.ts` | 10 | 0 | 0 |
| `middleware.spec.ts` | 22 | 0 | 0 |
| `recommendations.spec.ts` | 18 | 4 | 0 |
| `search.spec.ts` | 7 | 7 | 0 |
| `smoke.spec.ts` | 22 | 0 | 0 |
| `subscribe.spec.ts` | 18 | 0 | 0 |
| **Total** | **195** | **33** | **0** |

Iteration 1 could not launch a browser at all (see *Environment notes*). Iteration 2 was the
first real run: **179 passed, 41 failed, 8 skipped** — every failure in a pre-existing spec,
none in the new ones. Iteration 3, after the fixes below: **195 passed, 33 skipped, 0 failed**.

## Genuine failures fixed

All 41 iteration-2 failures were in specs that predate this pass. None were caused by the new
tests. Triage split them into one app defect and a set of stale test assertions.

### App defect — filed

- **[#26](https://github.com/xozai/JoseLeos.com/issues/26) — site search is unreachable on mobile viewports.**
  `SearchOverlay` is mounted inside the `hidden md:flex` desktop nav (`NavClient.tsx:72`), and the
  mobile menu has no search entry, so below the `md` breakpoint there is no trigger button and
  ⌘K does nothing. This is why all seven `search.spec.ts` tests failed under `mobile-chrome`
  while passing under `chromium`. Not fixed here (it is an app change, not a test change); the
  specs now skip on mobile with a pointer to the issue, so un-skipping them is the regression
  test once search is reachable.

### Test defects — fixed in this branch

- **`auth.spec.ts` (2 failures)** — the NextAuth mock returned a *relative* `url`
  (`"/login/verify"`) and `url: null`. next-auth v5's client runs `new URL(data.url)` on the
  response (`node_modules/next-auth/react.js`), which throws `TypeError: Invalid URL` on both,
  so `signIn()` rejected and the page neither navigated nor showed its error state. The mock now
  resolves to an absolute URL and signals failure through an `?error=` param, which is where the
  client actually reads the code from.
- **`smoke.spec.ts` (3 failures)** — assertions targeted copy the homepage no longer uses. The
  `h1` is `BUILDING <rotating word> THAT SHIP.`, not `Jose Leos`, and the CTAs are
  *View Selected Work* / *Read the Journal*, not *View My Work* / *Download CV*. Assertions now
  match the shipped copy and skip the rotating middle word. The nav-links test now opens the
  hamburger first on mobile, and the 404 test gets a 90s budget because `next dev` compiles the
  not-found route on first hit.
- **`contact.spec.ts` (1 failure)** — `text=/at least 2/i` matched both
  *"Name must be at least 2 characters"* and *"Message must be at least 20 characters"*, tripping
  strict mode. Now anchored to the name error.

## ENV failures (expected — no backend)

Skipped with an inline reason rather than deleted, so they light up again once a backend exists.

| Count | Why |
|---:|---|
| 14 | `blog-taxonomy.spec.ts` — 7 tests mock WPGraphQL from the page, but blog list / category / tag / newsletter pages fetch through Apollo **inside server components**. The request leaves from Node, so `page.route()` never sees it and the mock has no effect. Needs a live WordPress backend. |
| 4 | `recommendations.spec.ts` — the two detail-page tests, same server-side GraphQL cause. |
| 7 | `search.spec.ts` — skipped on `mobile-chrome` only, tracking issue #26. |
| 4 | `api-reactions.spec.ts` — `GET /api/react/[slug]` calls `kv.get()`/`kv.sismember()` with no try/catch, so it 500s without Vercel KV. These self-skip when the probe returns ≥500 and assert the real shape wherever KV is configured. |
| 4 | `api-revalidate.spec.ts` — the accept path needs `ISR_REVALIDATE_SECRET` exported to the test process; the rejection paths run everywhere. |

## Remaining issues

Observations that are not test failures and were **not** auto-fixed:

- **Rate limiting is invisible to the user.** `NewsletterCTA` collapses every non-success response
  into "Something went wrong — please try again", so a 429'd visitor gets no hint to retry later,
  even though the API returns `Retry-After`. Covered by a passing test that documents the current
  behaviour; worth a UX fix.
- **`GET /api/react/[slug]` has no KV fallback.** Unlike `lib/rate-limit.ts`, which fails open, the
  reactions GET propagates the KV error as a 500. Degrading to zero counts would make blog posts
  render cleanly when KV is down.
- **The E2E suite does not run in CI.** `.github/workflows/` contains only `pr-title.yml` and
  `release-please.yml`. That is how the stale assertions above survived — the specs added in #22
  appear never to have been executed against a browser. A workflow running `npm run test:e2e`
  would have caught all of them.
- **`/api/views/[slug]` is still uncovered.** Same unguarded-KV shape as the reactions GET, so
  route-level tests would be skip-only in this environment.
- **Signed-in coverage is absent throughout.** Every gated assertion here is the signed-out half.
  Exercising the authenticated paths (reaction dedup, bookmark toggling, `/dashboard` owner-only
  vs `/account` member) needs a minted session cookie plus KV, which is a fixture change beyond
  this pass.

## Environment notes

The bundled Playwright chromium could not be installed on this machine — downloads from the
Playwright CDN stall (a day-old stuck `playwright install` was already holding the browser-cache
lock, and a fresh attempt moved 1 MB in 30 minutes). Iteration 1 therefore failed every
browser-backed test with `browserType.launch: Executable doesn't exist`, which is an environment
failure, not a code one; the route-level API tests all passed in that run.

Iterations 2 and 3 ran against the locally installed Google Chrome via a temporary
`channel: "chrome"` override that reused the committed config verbatim. That override file is
**not** part of this branch — `playwright.config.ts` is unchanged and CI still uses the bundled
chromium. Re-running here needs either a working `npx playwright install chromium` or the same
local override.